### PR TITLE
Fix missing API service imports

### DIFF
--- a/ApiService.js
+++ b/ApiService.js
@@ -1,3 +1,6 @@
+import axios from 'axios';
+import AuthService from './userAuthService';
+
 const baseURL = process.env.REACT_APP_API_URL || '';
 
 const axiosInstance = axios.create({

--- a/userAuthService.js
+++ b/userAuthService.js
@@ -66,6 +66,14 @@ const userAuthService = {
     clearAuthHeader();
   },
 
+  setAuthHeader: (token) => {
+    setAuthHeader(token);
+  },
+
+  getRefreshToken: () => {
+    return localStorage.getItem(REFRESH_TOKEN_KEY);
+  },
+
   getAccessToken: () => {
     return localStorage.getItem(ACCESS_TOKEN_KEY);
   },


### PR DESCRIPTION
## Summary
- rename `setupAxiosInstance.js` to `ApiService.js`
- import axios and auth service in `ApiService.js`
- expose `setAuthHeader` and `getRefreshToken` through `userAuthService`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ffa4a8f8832b952d5bc0895bb1b3