### PR TITLE
Fix newPostComposer missing context import

### DIFF
--- a/src/components/newPostComposer.jsx
+++ b/src/components/newPostComposer.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { UserContext } from '../App';
+import { UserContext, TokenContext } from '../App';
 
 const MAX_CHAR = 280;
 const TOKEN_COST = 10;


### PR DESCRIPTION
## Summary
- import TokenContext in `newPostComposer.jsx`

## Testing
- `npm run lint` *(fails: 142 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6859ccb26750832b95e73c3b229bd774