### PR TITLE
Add basic pages and test

### DIFF
--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -1,1 +1,13 @@
- 
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import App from '../App';
+
+test('renders navigation links', () => {
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
+  expect(screen.getByText(/Home/i)).toBeInTheDocument();
+});

--- a/src/components/configureRouteAccess.jsx
+++ b/src/components/configureRouteAccess.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../contexts/AuthContext'
 import LandingPage from '../pages/LandingPage'
 import FeedView from '../pages/FeedView'
 import SettingsPage from '../pages/SettingsPage'

--- a/src/pages/FeedView.jsx
+++ b/src/pages/FeedView.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function FeedView() {
+  return (
+    <div className="feed-view">
+      <h1>Feed</h1>
+      <p>The satirical feed will appear here.</p>
+    </div>
+  );
+}
+
+export default FeedView;

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+function LandingPage() {
+  const { login, isAuthenticated, user } = useAuth();
+
+  const handleLogin = async () => {
+    await login({ name: 'Guest' });
+  };
+
+  if (isAuthenticated) {
+    return (
+      <div className="landing-page">
+        <h1>Welcome back, {user?.name}</h1>
+        <p>You are logged in to FaceCrook.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="landing-page">
+      <h1>Welcome to FaceCrook</h1>
+      <p>A satire-filled crypto social experience.</p>
+      <button type="button" onClick={handleLogin}>Enter</button>
+    </div>
+  );
+}
+
+export default LandingPage;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function SettingsPage() {
+  return (
+    <div className="settings-page">
+      <h1>Settings</h1>
+      <p>Account preferences will be configurable here.</p>
+    </div>
+  );
+}
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add skeleton pages for Landing, Feed, and Settings
- update route config to import `useAuth` from contexts
- include smoke test covering navigation

## Testing
- `CI=true npm test --silent --no-color`

------
https://chatgpt.com/codex/tasks/task_e_685a0349e3c0832b81ee9215a512f237